### PR TITLE
Rebuild the Kornia example to update the updated link in the old built notebook

### DIFF
--- a/lightning_examples/augmentation_kornia/augmentation.py
+++ b/lightning_examples/augmentation_kornia/augmentation.py
@@ -34,7 +34,7 @@ sn.set()
 # where the augmentation_kornia (also subclassing `nn.Module`) are combined with other PyTorch components
 # such as `nn.Sequential`.
 #
-# Checkout the different augmentation operators in Kornia docs and experiment yourself !
+# Checkout the different augmentation operators in Kornia docs and experiment yourself!
 
 
 # %%


### PR DESCRIPTION
## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [n/a] Did you make sure to **update the docs**?
- [n/a] Did you write any new **necessary tests**?

## What does this PR do?

Fixes #204.

The warning I'm trying to fix in this PR
```
(notebooks/lightning_examples/augmentation_kornia: line  128) The name of the builder is: linkcheck
Warning, treated as error:
/Users/nitta/work/github.com/Lightning-AI/tutorials/docs/source/notebooks/lightning_examples/augmentation_kornia.ipynb.rst:128:broken link: https://www.kornia.org (HTTPSConnectionPool(host='www.kornia.org', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:997)'))))
make: *** [linkcheck] Error 2
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
