### PR TITLE
Minor Fine-Tuning Scheduler Tutorial Updates for Lightning 1.9.x

### DIFF
--- a/_requirements/devel.txt
+++ b/_requirements/devel.txt
@@ -2,5 +2,5 @@ virtualenv>=20.10
 jupytext>=1.10, <1.15  # converting
 pytest>=6.0, <7.0
 # testing with own fork with extended cell timeout
-https://github.com/Borda/nbval/archive/refs/heads/master.zip
+https://github.com/Borda/nbval/archive/refs/heads/timeout-limit.zip
 papermill>=2.3.4, <2.5.0  # render

--- a/lightning_examples/finetuning-scheduler/.meta.yml
+++ b/lightning_examples/finetuning-scheduler/.meta.yml
@@ -1,20 +1,19 @@
 title: Fine-Tuning Scheduler
 author: "[Dan Dale](https://github.com/speediedan)"
 created: 2021-11-29
-updated: 2022-09-20
+updated: 2023-01-24
 license: CC BY-SA
 build: 0
 tags:
   - Fine-Tuning
 description: |
   This notebook introduces the [Fine-Tuning Scheduler](https://finetuning-scheduler.readthedocs.io/en/stable/index.html) extension
-  and demonstrates the use of it to fine-tune a small foundational model on the
+  and demonstrates the use of it to fine-tune a small foundation model on the
   [RTE](https://huggingface.co/datasets/viewer/?dataset=super_glue&config=rte) task of
   [SuperGLUE](https://super.gluebenchmark.com/) with iterative early-stopping defined according to a user-specified
   schedule. It uses Hugging Face's ``datasets`` and ``transformers`` libraries to retrieve the relevant benchmark data
-  and foundational model weights. The required dependencies are installed via the finetuning-scheduler ``[examples]`` extra.
+  and foundation model weights. The required dependencies are installed via the finetuning-scheduler ``[examples]`` extra.
 requirements:
-  - finetuning-scheduler[examples]>=0.3.0
-  - datasets<2.8.0  # todo: AttributeError: module 'datasets.arrow_dataset' has no attribute 'Batch'
+  - finetuning-scheduler[examples]>=0.4.0
 accelerator:
   - GPU


### PR DESCRIPTION
## What does this PR do?

Three minor updates to the Fine-Tuning Scheduler tutorial to better support the release of Lightning 1.9.x (supported by Fine-Tuning Scheduler 0.4.x)

- updated the list of supported strategies (**Multi-phase Scheduled Fine-Tuning with FSDP** is now supported! Noted deprecation of Fairscale-based strategies like ``ddp_sharded``)
	- [See the FSDP tutorial here if interested.](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/fsdp_scheduled_fine_tuning.html)
- Added references to [``StrategyAdapter``](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.strategy_adapters.html#finetuning_scheduler.strategy_adapters.StrategyAdapter)s. If users want to extend Fine-Tuning Scheduler (FTS) to use a custom, currently unsupported strategy or override current FTS behavior in the context of a given training strategy, subclassing ``StrategyAdapter`` is now a way to do so. See [``FSDPStrategyAdapter``](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.strategy_adapters.html#finetuning_scheduler.strategy_adapters.FSDPStrategyAdapter) for an example implementation.
- replaced a typehint reference to a ``datasets`` class (``Batch``) that had been replaced in 2.8.0 necessitating the package ceiling in the FTS (0.3.x) (Lightning 1.8.x) version of the tutorial 

I recognize [#224](https://github.com/Lightning-AI/tutorials/pull/224) might need to get merged before this PR can be. When #224 is passing, I'll update this PR to verify it complies with the new ``ruff`` validation/transformation. ``ruff`` looks amazing btw!

## Before submitting

- [X] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [X] Did you make sure to **update the docs**?
- [X] Did you write any new **necessary tests**?
