### PR TITLE
Fine-Tuning Scheduler Tutorial Updates for Lightning 2.0.x

### DIFF
--- a/lightning_examples/finetuning-scheduler/.meta.yml
+++ b/lightning_examples/finetuning-scheduler/.meta.yml
@@ -1,7 +1,7 @@
 title: Fine-Tuning Scheduler
 author: "[Dan Dale](https://github.com/speediedan)"
 created: 2021-11-29
-updated: 2023-01-24
+updated: 2023-03-15
 license: CC BY-SA
 build: 0
 tags:
@@ -14,8 +14,7 @@ description: |
   schedule. It uses Hugging Face's ``datasets`` and ``transformers`` libraries to retrieve the relevant benchmark data
   and foundation model weights. The required dependencies are installed via the finetuning-scheduler ``[examples]`` extra.
 requirements:
-  - finetuning-scheduler[examples]>=0.4.0
-  - datasets<2.8.0  # todo: AttributeError: module 'datasets.arrow_dataset' has no attribute 'Batch'
-  - lightning>=2.0.0rc0
+  - finetuning-scheduler[examples]>=2.0.0
+  - torch>=1.12.1  # to avoid https://github.com/pytorch/pytorch/issues/80809 with torch 1.12.0
 accelerator:
   - GPU

--- a/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
+++ b/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
@@ -13,7 +13,7 @@
 #
 # Setup is straightforward, just install from PyPI! Since this notebook-based example requires a few additional packages (e.g.
 # ``transformers``, ``sentencepiece``), we installed the ``finetuning-scheduler`` package with the ``[examples]`` extra above.
-# Once the ``finetuning-scheduler`` package is installed, the [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) callback is available for use with PyTorch Lightning.
+# Once the ``finetuning-scheduler`` package is installed, the [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) callback (FTS) is available for use with Lightning.
 # For additional installation options, please see the Fine-Tuning Scheduler [README](https://github.com/speediedan/finetuning-scheduler/blob/main/README.md).
 #
 #
@@ -34,7 +34,7 @@
 # criteria (a multi-phase extension of ``EarlyStopping`` packaged with FinetuningScheduler), user-specified epoch transitions or a composition of the two (the default mode).
 # A [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) training session completes when the
 # final phase of the schedule has its stopping criteria met. See
-# the [early stopping documentation](https://lightning.ai/docs/pytorch/stable/api/pytorch_lightning.callbacks.EarlyStopping.html) for more details on that callback's configuration.
+# the [early stopping documentation](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.EarlyStopping.html) for more details on that callback's configuration.
 #
 # ![FinetuningScheduler explicit loss animation](fts_explicit_loss_anim.gif){height="272px" width="376px"}
 
@@ -51,7 +51,7 @@
 # </div>
 #
 # ```python
-# from pytorch_lightning import Trainer
+# from lightning.pytorch import Trainer
 # from finetuning_scheduler import FinetuningScheduler
 # trainer = Trainer(callbacks=[FinetuningScheduler()])
 # ```
@@ -72,7 +72,7 @@
 #    ``LightningModule`` subclass with the suffix ``_ft_schedule.yaml``.
 #
 # ```python
-#     from pytorch_lightning import Trainer
+#     from lightning.pytorch import Trainer
 #     from finetuning_scheduler import FinetuningScheduler
 #     trainer = Trainer(callbacks=[FinetuningScheduler(gen_ft_sched_only=True)])
 # ```
@@ -85,7 +85,7 @@
 #    [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) to commence scheduled training:
 #
 # ```python
-# from pytorch_lightning import Trainer
+# from lightning.pytorch import Trainer
 # from finetuning_scheduler import FinetuningScheduler
 #
 # trainer = Trainer(callbacks=[FinetuningScheduler(ft_schedule="/path/to/my/schedule/my_schedule.yaml")])
@@ -126,7 +126,8 @@
 # from pytorch_lightning import Trainer
 # from finetuning_scheduler import FinetuningScheduler
 # trainer = Trainer(callbacks=[FinetuningScheduler()])
-# trainer.fit(..., ckpt_path="some/path/to/my_checkpoint.ckpt")
+# trainer.ckpt_path="some/path/to/my_checkpoint.ckpt"
+# trainer.fit(...)
 # ```
 #
 # Training will resume at the depth/level of the provided checkpoint according to the specified schedule. Schedules can be altered between training sessions but schedule compatibility is left to the user for maximal flexibility. If executing a user-defined schedule, typically the same schedule should be provided for the original and resumed training sessions.
@@ -135,24 +136,21 @@
 #
 # ```python
 # trainer = Trainer(callbacks=[FinetuningScheduler()])
-# trainer.fit(..., ckpt_path="some/path/to/my_kth_best_checkpoint.ckpt")
+# trainer.ckpt_path="some/path/to/my_kth_best_checkpoint.ckpt"
+# trainer.fit(...)
 # ```
 #
-# Note that similar to the behavior of [ModelCheckpoint](https://lightning.ai/docs/pytorch/stable/api/pytorch_lightning.callbacks.ModelCheckpoint.html), (specifically [this PR](https://github.com/Lightning-AI/lightning/pull/12045)),
-# when resuming training with a different [FTSCheckpoint](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts_supporters.html#finetuning_scheduler.fts_supporters.FTSCheckpoint) ``dirpath`` from the provided
+# Note that similar to the behavior of [ModelCheckpoint](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html), when resuming training with a
+# different [FTSCheckpoint](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts_supporters.html#finetuning_scheduler.fts_supporters.FTSCheckpoint) ``dirpath`` from the provided
 # checkpoint, the new training session's checkpoint state will be re-initialized at the resumption depth with the provided checkpoint being set as the best checkpoint.
 
 # %% [markdown]
 # <div class="alert alert-warning">
 #
-# **Note:** Currently, [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) supports the following strategy types:
+# **Note:** Currently, [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) supports the following distributed strategy types:
 #
-# - ``ddp`` (and alias ``ddp_find_unused_parameters_false``)
-# - ``fsdp_native`` (and alias ``fsdp_native_full_shard_offload``)
-# - ``ddp_spawn`` (and aliases ``ddp_fork``, ``ddp_notebook``)
-# - ``dp``
-# - ``ddp_sharded`` (deprecated, to be removed in 2.0)
-# - ``ddp_sharded_spawn`` (deprecated, to be removed in 2.0)
+# - ``ddp`` (and aliases ``ddp_find_unused_parameters_false``, ``ddp_find_unused_parameters_true``, ``ddp_spawn``, ``ddp_fork``, ``ddp_notebook``)
+# - ``fsdp`` (and alias ``fsdp_cpu_offload``)
 #
 # Custom or officially unsupported strategies can be used by setting [FinetuningScheduler.allow_untested](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html?highlight=allow_untested#finetuning_scheduler.fts.FinetuningScheduler.params.allow_untested) to ``True``.
 # Note that most currently unsupported strategies are so because they require varying degrees of modification to be compatible. For example, ``deepspeed`` will require a [StrategyAdapter](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.strategy_adapters.html#finetuning_scheduler.strategy_adapters.StrategyAdapter) to be written (similar to the one for ``FSDP``, [FSDPStrategyAdapter](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.strategy_adapters.html#finetuning_scheduler.strategy_adapters.FSDPStrategyAdapter)) before support can be added (PRs welcome!),
@@ -171,32 +169,24 @@
 import os
 import warnings
 from datetime import datetime
-from typing import Any, Dict, List, Optional
-
-from packaging.version import Version
+from typing import Any, Dict, Optional
 
 import sentencepiece as sp  # noqa: F401 # isort: split
 import datasets
 import evaluate
-import pytorch_lightning as pl
+import lightning.pytorch as pl
 import torch
 from datasets import logging as datasets_logging
-from lightning_fabric.accelerators.cuda import is_cuda_available
-from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
-from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
-from pytorch_lightning.utilities import rank_zero_warn
+from lightning.fabric.accelerators.cuda import is_cuda_available
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
+from lightning.pytorch.loggers.tensorboard import TensorBoardLogger
+from lightning.pytorch.utilities import rank_zero_warn
+from torch.optim.adamw import AdamW
 from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts
 from torch.utils.data import DataLoader
 from transformers import AutoConfig, AutoModelForSequenceClassification, AutoTokenizer
 from transformers import logging as transformers_logging
 from transformers.tokenization_utils_base import BatchEncoding
-
-if Version(torch.__version__) == Version("1.12.0") or torch.__version__.startswith("1.12.0"):
-    # we need to use a patched version of AdamW to fix https://github.com/pytorch/pytorch/issues/80809
-    # and allow examples to succeed with torch 1.12.0 (this torch bug is fixed in 1.12.1)
-    from fts_examples.patched_adamw import AdamW
-else:
-    from torch.optim.adamw import AdamW
 
 # %%
 # Import the `FinetuningScheduler` PyTorch Lightning extension module we want to use. This will import all necessary callbacks.
@@ -348,6 +338,8 @@ class RteBoolqModule(pl.LightningModule):
                 "default".
         """
         super().__init__()
+        self.training_step_outputs = []
+        self.validation_step_outputs = []
         if task_name not in TASK_NUM_LABELS.keys():
             rank_zero_warn(f"Invalid task_name {task_name!r}. Proceeding with the default task: {DEFAULT_TASK!r}")
             task_name = DEFAULT_TASK
@@ -376,13 +368,15 @@ class RteBoolqModule(pl.LightningModule):
     def forward(self, **inputs):
         return self.model(**inputs)
 
-    def training_step(self, batch, batch_idx):
-        outputs = self(**batch)
-        loss = outputs[0]
-        self.log("train_loss", loss)
+    def training_step(self, batch, batch_idx: int):
+        loss = self(**batch)[0]
+        self.training_step_outputs.append(loss)
+        self.log("train_loss", loss, prog_bar=True)
         return loss
 
-    def training_epoch_end(self, outputs: List[Any]) -> None:
+    def on_train_epoch_end(self):
+        if self.training_step_outputs:
+            self.training_step_outputs.clear()
         if self.finetuningscheduler_callback:
             self.log("finetuning_schedule_depth", float(self.finetuningscheduler_callback.curr_depth))
 
@@ -394,43 +388,20 @@ class RteBoolqModule(pl.LightningModule):
         elif self.num_labels == 1:
             preds = logits.squeeze()
         labels = batch["labels"]
+        self.validation_step_outputs.append(val_loss)
         self.log("val_loss", val_loss, prog_bar=True)
         metric_dict = self.metric.compute(predictions=preds, references=labels)
         self.log_dict(metric_dict, prog_bar=True)
 
-    def _init_param_groups(self) -> List[Dict]:
-        """Initialize the parameter groups. Used to ensure weight_decay is not applied to our specified bias
-        parameters when we initialize the optimizer.
-
-        Returns:
-            List[Dict]: A list of parameter group dictionaries.
-        """
-        return [
-            {
-                "params": [
-                    p
-                    for n, p in self.model.named_parameters()
-                    if not any(nd in n for nd in self.no_decay) and p.requires_grad
-                ],
-                "weight_decay": self.hparams.optimizer_init["weight_decay"],
-            },
-            {
-                "params": [
-                    p
-                    for n, p in self.model.named_parameters()
-                    if any(nd in n for nd in self.no_decay) and p.requires_grad
-                ],
-                "weight_decay": 0.0,
-            },
-        ]
+    def on_validation_epoch_end(self):
+        self.validation_step_outputs.clear()
 
     def configure_optimizers(self):
-        # the phase 0 parameters will have been set to require gradients during setup
-        # you can initialize the optimizer with a simple requires.grad filter as is often done,
-        # but in this case we pass a list of parameter groups to ensure weight_decay is
-        # not applied to the bias parameter (for completeness, in this case it won't make much
-        # performance difference)
-        optimizer = AdamW(params=self._init_param_groups(), **self.hparams.optimizer_init)
+        # With FTS >= 2.0, ``FinetuningScheduler`` simplifies initial optimizer configuration by ensuring the optimizer
+        # configured here will optimize the parameters (and only those parameters) scheduled to be optimized in phase 0
+        # of the current fine-tuning schedule. This auto-configuration can be disabled if desired by setting
+        # ``enforce_phase0_params`` to ``False``.
+        optimizer = AdamW(params=self.model.parameters(), **self.hparams.optimizer_init)
         scheduler = {
             "scheduler": CosineAnnealingWarmRestarts(optimizer, **self.hparams.lr_scheduler_init),
             "interval": "epoch",
@@ -573,7 +544,7 @@ def train() -> None:
     trainer = pl.Trainer(
         enable_progress_bar=enable_progress_bar,
         max_epochs=100,
-        precision=16,
+        precision="16-mixed",
         accelerator="auto",
         devices=1 if is_cuda_available() else None,
         callbacks=callbacks,
@@ -594,7 +565,7 @@ train()
 #
 # We'll need to update our callbacks list, using the core PL ``EarlyStopping`` and ``ModelCheckpoint`` callbacks for the
 # ``nofts_baseline`` (which operate identically to their FTS analogs apart from the recursive training support).
-# For both core PyTorch Lightning and user-registered callbacks, we can define our callbacks using a dictionary as we do
+# For both core Lightning and user-registered callbacks, we can define our callbacks using a dictionary as we do
 # with the LightningCLI. This allows us to avoid managing imports and support more complex configuration separated from
 # code.
 #
@@ -630,7 +601,7 @@ for scenario_name, scenario_callbacks in scenario_callbacks.items():
 # See the [tensorboard experiment summaries](https://tensorboard.dev/experiment/n7U8XhrzRbmvVzC4SQSpWw/) to get a sense
 # of the relative computational and performance tradeoffs associated with these [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) configurations.
 # The summary compares a full ``fts_implicit`` execution to ``fts_explicit`` and ``nofts_baseline`` scenarios using DDP
-# training with 2 GPUs. The full logs/schedules and detailed system configuration used for all three scenarios are available
+# training with 2 GPUs. The full logs/schedules for all three scenarios are available
 # [here](https://drive.google.com/file/d/1LrUcisRLHeJgh_BDOOD_GUBPp5iHAkoR/view?usp=sharing) and the checkpoints
 # produced in the scenarios [here](https://drive.google.com/file/d/1t7myBgcqcZ9ax_IT9QVk-vFH_l_o5UXB/view?usp=sharing)
 # (caution, ~3.5GB).
@@ -638,8 +609,7 @@ for scenario_name, scenario_callbacks in scenario_callbacks.items():
 # [![fts_explicit_accuracy](fts_explicit_accuracy.png){height="315px" width="492px"}](https://tensorboard.dev/experiment/n7U8XhrzRbmvVzC4SQSpWw/#scalars&_smoothingWeight=0&runSelectionState=eyJmdHNfZXhwbGljaXQiOnRydWUsIm5vZnRzX2Jhc2VsaW5lIjpmYWxzZSwiZnRzX2ltcGxpY2l0IjpmYWxzZX0%3D)
 # [![nofts_baseline](nofts_baseline_accuracy.png){height="316px" width="505px"}](https://tensorboard.dev/experiment/n7U8XhrzRbmvVzC4SQSpWw/#scalars&_smoothingWeight=0&runSelectionState=eyJmdHNfZXhwbGljaXQiOmZhbHNlLCJub2Z0c19iYXNlbGluZSI6dHJ1ZSwiZnRzX2ltcGxpY2l0IjpmYWxzZX0%3D)
 #
-# Note that the results above may vary to a small degree from the tensorboard summaries generated by this notebook
-# which used DP, 1 GPU and likely when you're running this, different versions of certain software components (e.g. pytorch, transformers).
+# Note that given execution context differences, there could be a modest variation in performance from the tensorboard summaries generated by this notebook.
 #
 # [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) expands the space of possible fine-tuning schedules and the composition of more sophisticated schedules can
 # yield marginal fine-tuning performance gains. That stated, it should be emphasized the primary utility of [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) is to grant


### PR DESCRIPTION
A few minor updates to the Fine-Tuning Scheduler Tutorial to simplify it slightly and better accommodate the Lightning and PyTorch 2.0.x releases. 

### Changed

1. Support for PyTorch and PyTorch Lightning 2.0.0! Note that ``lightning>=2.0.0`` is a dependency of ``finetuning-scheduler`` 2.0.0 which this tutorial requires.
2. Use the unified `lightning` package rather than the standalone package. Fine-Tuning Scheduler (FTS) by default depends upon the `lightning` package rather than the standalone `pytorch-lightning` package beginning with FTS 2.0 (though the latter can still be installed and used similar to Lightning).
3. Leverage a feature now available in ``finetuning-scheduler`` 2.0.0 to simplify the example.
4. Updated the list of distributed strategies FTS supports as of FTS 2.x.
5. Further simplify the example by requiring torch>=1.12.1 (to avoid https://github.com/pytorch/pytorch/issues/80809 with torch 1.12.0 and the version checking/special patched version of AdamW that was required for 1.12.0)

Congrats on the successful Lightning 2.0 launch!! :rocket: :tada: 
## Before submitting

- [X] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [X] Did you make sure to **update the docs**?
- [X] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
