### PR TITLE
Fine-Tuning Scheduler Tutorial Update

### DIFF
--- a/_requirements/default.txt
+++ b/_requirements/default.txt
@@ -1,5 +1,5 @@
 setuptools==67.6.1
-matplotlib>=3.0.0, <3.4.0
+matplotlib>=3.0.0, <3.8.0
 ipython[notebook]>=8.0.0, <8.12.0
 torch>=1.8.1, <1.14.0
 pytorch-lightning>=1.4, <2.0.0

--- a/lightning_examples/finetuning-scheduler/.meta.yml
+++ b/lightning_examples/finetuning-scheduler/.meta.yml
@@ -1,7 +1,7 @@
 title: Fine-Tuning Scheduler
 author: "[Dan Dale](https://github.com/speediedan)"
 created: 2021-11-29
-updated: 2023-03-15
+updated: 2023-04-06
 license: CC BY-SA
 build: 0
 tags:

--- a/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
+++ b/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
@@ -481,7 +481,7 @@ optimizer_init = {"weight_decay": 1e-05, "eps": 1e-07, "lr": 1e-05}
 # justified [(Loshchilov & Hutter, 2016)](#f4), the particular values provided here are primarily empircally driven.
 #
 # [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) also supports LR scheduler
-# reinitialization in both explicit and implicit finetuning schedule modes. See the [advanced usage documentation](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/lr_scheduler_reinitialization.html) for explanations and demonstration of the extension's support for more complex requirements.
+# reinitialization in both explicit and implicit finetuning schedule modes. See the advanced usage documentation ([LR scheduler reinitialization](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/lr_scheduler_reinitialization.html), [optimizer reinitialization](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/optimizer_reinitialization.html)) for explanations and demonstration of the extension's support for more complex requirements.
 # </div>
 
 

--- a/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
+++ b/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
@@ -480,8 +480,8 @@ optimizer_init = {"weight_decay": 1e-05, "eps": 1e-07, "lr": 1e-05}
 # used in other pytorch-lightning tutorials) also work with FinetuningScheduler. Though the LR scheduler is theoretically
 # justified [(Loshchilov & Hutter, 2016)](#f4), the particular values provided here are primarily empircally driven.
 #
-# [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) also supports LR scheduler
-# reinitialization in both explicit and implicit finetuning schedule modes. See the advanced usage documentation ([LR scheduler reinitialization](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/lr_scheduler_reinitialization.html), [optimizer reinitialization](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/optimizer_reinitialization.html)) for explanations and demonstration of the extension's support for more complex requirements.
+# [FinetuningScheduler](https://finetuning-scheduler.readthedocs.io/en/stable/api/finetuning_scheduler.fts.html#finetuning_scheduler.fts.FinetuningScheduler) also supports both optimizer and LR scheduler
+# reinitialization in explicit and implicit finetuning schedule modes. See the advanced usage documentation ([LR scheduler reinitialization](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/lr_scheduler_reinitialization.html), [optimizer reinitialization](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/optimizer_reinitialization.html)) for explanations and demonstration of the extension's support for more complex requirements.
 # </div>
 
 


### PR DESCRIPTION
## Before submitting

- [X] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [X] Did you make sure to **update the docs**?
- [X] Did you write any new **necessary tests**?

## What does this PR do?

A single update to the Fine-Tuning Scheduler Tutorial to indicate that optimizer reinitialization is now supported! :tada: :rocket:  
A link to the relevant [advanced tutorial](https://finetuning-scheduler.readthedocs.io/en/stable/advanced/optimizer_reinitialization.html) in the official FTS documentation is included. Hoping this might also perhaps re-trigger an update to get the ``2.0.x`` version of the tutorial published. 

(as an aside, the more permissive ``matplotlib`` version dependency that is ready to be merged in [#247](https://github.com/Lightning-AI/tutorials/pull/247) is included in this PR because I saw the older version started having installation issues)

Thanks again to Lightning team for your continuously impressive work!

@Borda @awaelchli 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
