### PR TITLE
cli: allow skip notebooks from being copied

### DIFF
--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -622,15 +622,17 @@ class AssistantCLI:
             patterns: patterns to use when glob-ing notebooks
             ignore: ignore some specific notebooks even when the given string is in path
         """
+        all_ipynb = []
+        for pattern in patterns:
+            all_ipynb += glob.glob(os.path.join(path_root, DIR_NOTEBOOKS, pattern, "*.ipynb"))
+        os.makedirs(os.path.join(docs_root, path_docs_ipynb), exist_ok=True)
         if ignore and not isinstance(ignore, (list, set, tuple)):
             ignore = [ignore]
         elif not ignore:
             ignore = []
-        ls_ipynb = [glob.glob(os.path.join(path_root, DIR_NOTEBOOKS, sub, "*.ipynb")) for sub in patterns]
-        os.makedirs(os.path.join(docs_root, path_docs_ipynb), exist_ok=True)
 
         ipynb_content = []
-        for path_ipynb in tqdm.tqdm(ls_ipynb):
+        for path_ipynb in tqdm.tqdm(all_ipynb):
             if any(skip in path_ipynb for skip in ignore):
                 print(f"ignore/skip copy: {path_ipynb}")
                 continue

--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -624,6 +624,8 @@ class AssistantCLI:
         """
         if ignore and not isinstance(ignore, (list, set, tuple)):
             ignore = [ignore]
+        elif not ignore:
+            ignore = []
         ls_ipynb = [glob.glob(os.path.join(path_root, DIR_NOTEBOOKS, sub, "*.ipynb")) for sub in patterns]
         os.makedirs(os.path.join(docs_root, path_docs_ipynb), exist_ok=True)
 

--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -610,6 +610,7 @@ class AssistantCLI:
         path_docs_ipynb: str = "notebooks",
         path_docs_images: str = "_static/images",
         patterns: Sequence[str] = (".", "**"),
+        ignore: Optional[Sequence[str]] = None,
     ) -> None:
         """Copy all notebooks from a folder to doc folder.
 
@@ -619,40 +620,57 @@ class AssistantCLI:
             path_docs_ipynb: destination path to the notebooks' location relative to ``docs_root``
             path_docs_images: destination path to the images' location relative to ``docs_root``
             patterns: patterns to use when glob-ing notebooks
+            ignore: ignore some specific notebooks even when the given string is in path
         """
-        ls_ipynb = []
-        for sub in patterns:
-            ls_ipynb += glob.glob(os.path.join(path_root, DIR_NOTEBOOKS, sub, "*.ipynb"))
-
+        if ignore and not isinstance(ignore, (list, set, tuple)):
+            ignore = [ignore]
+        ls_ipynb = [glob.glob(os.path.join(path_root, DIR_NOTEBOOKS, sub, "*.ipynb")) for sub in patterns]
         os.makedirs(os.path.join(docs_root, path_docs_ipynb), exist_ok=True)
+
         ipynb_content = []
         for path_ipynb in tqdm.tqdm(ls_ipynb):
-            ipynb = path_ipynb.split(os.path.sep)
-            sub_ipynb = os.path.sep.join(ipynb[ipynb.index(DIR_NOTEBOOKS) + 1 :])
-            new_ipynb = os.path.join(docs_root, path_docs_ipynb, sub_ipynb)
-            os.makedirs(os.path.dirname(new_ipynb), exist_ok=True)
+            if any(skip in path_ipynb for skip in ignore):
+                print(f"ignore/skip copy: {path_ipynb}")
+                continue
+            path_ipynb_in_dir = AssistantCLI._copy_notebook(
+                path_ipynb,
+                path_root=path_root,
+                docs_root=docs_root,
+                path_docs_ipynb=path_docs_ipynb,
+                path_docs_images=path_docs_images,
+            )
+            ipynb_content.append(os.path.join(path_docs_ipynb, path_ipynb_in_dir))
 
-            path_meta = path_ipynb.replace(".ipynb", ".yaml")
-            path_thumb = AssistantCLI._resolve_path_thumb(path_ipynb, path_meta)
+    @staticmethod
+    def _copy_notebook(
+        path_ipynb: str, path_root: str, docs_root: str, path_docs_ipynb: str, path_docs_images: str
+    ) -> str:
+        """Copy particular notebook."""
+        ipynb = path_ipynb.split(os.path.sep)
+        path_ipynb_in_dir = os.path.sep.join(ipynb[ipynb.index(DIR_NOTEBOOKS) + 1 :])
+        new_ipynb = os.path.join(docs_root, path_docs_ipynb, path_ipynb_in_dir)
+        os.makedirs(os.path.dirname(new_ipynb), exist_ok=True)
 
-            if path_thumb is not None:
-                new_thumb = os.path.join(docs_root, path_docs_images, path_thumb)
-                old_path_thumb = os.path.join(path_root, DIR_NOTEBOOKS, path_thumb)
-                os.makedirs(os.path.dirname(new_thumb), exist_ok=True)
-                copyfile(old_path_thumb, new_thumb)
-                path_thumb = os.path.join(path_docs_images, path_thumb)
+        path_meta = path_ipynb.replace(".ipynb", ".yaml")
+        path_thumb = AssistantCLI._resolve_path_thumb(path_ipynb, path_meta)
 
-            print(f"{path_ipynb} -> {new_ipynb}")
+        if path_thumb is not None:
+            new_thumb = os.path.join(docs_root, path_docs_images, path_thumb)
+            old_path_thumb = os.path.join(path_root, DIR_NOTEBOOKS, path_thumb)
+            os.makedirs(os.path.dirname(new_thumb), exist_ok=True)
+            copyfile(old_path_thumb, new_thumb)
+            path_thumb = os.path.join(path_docs_images, path_thumb)
 
-            with open(path_ipynb) as f:
-                ipynb = json.load(f)
+        print(f"{path_ipynb} -> {new_ipynb}")
 
-            ipynb["cells"].append(AssistantCLI._get_card_item_cell(path_ipynb, path_meta, path_thumb))
+        with open(path_ipynb) as fopen:
+            ipynb = json.load(fopen)
 
-            with open(new_ipynb, "w") as f:
-                json.dump(ipynb, f)
+        ipynb["cells"].append(AssistantCLI._get_card_item_cell(path_ipynb, path_meta, path_thumb))
 
-            ipynb_content.append(os.path.join("notebooks", sub_ipynb))
+        with open(new_ipynb, "w") as fopen:
+            json.dump(ipynb, fopen, indent=4)
+        return path_ipynb_in_dir
 
     @staticmethod
     def update_env_details(folder: str, base_path: str = DIR_NOTEBOOKS) -> str:

--- a/_docs/source/conf.py
+++ b/_docs/source/conf.py
@@ -42,7 +42,12 @@ github_repo = project
 
 # -- Project documents -------------------------------------------------------
 
-AssistantCLI.copy_notebooks(_PATH_ROOT, _PATH_HERE)
+AssistantCLI.copy_notebooks(
+    _PATH_ROOT,
+    _PATH_HERE,
+    # ToDo: fix coping this specific notebooks, some JSON encode issue
+    ignore=["course_UvA-DL/13-contrastive-learning"],
+)
 
 # with open(os.path.join(_PATH_HERE, 'ipynb_content.rst'), 'w') as fp:
 #     fp.write(os.linesep.join(ipynb_content))


### PR DESCRIPTION
## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## What does this PR do?

Seems we have some problems with course 13:
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/sphinx/config.py", line 350, in eval_config_file
    exec(code, namespace)
  File "/home/runner/work/lightning/lightning/docs/source-pytorch/conf.py", line 68, in <module>
    assist_nb.AssistantCLI.copy_notebooks(
  File "/home/runner/work/lightning/lightning/docs/source-pytorch/../../_notebooks/.actions/assistant.py", line 648, in copy_notebooks
    ipynb = json.load(f)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/json/decoder.py", line 3[37](https://github.com/Lightning-AI/lightning/actions/runs/6493366271/job/17634148105?pr=18787#step:9:38), in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
Which need to be investigated and fixed, but to unblock the docs building, let's add argument which would skip copying some specific notebooks

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
