### PR TITLE
ci: dont crash if testing matrix is empty

### DIFF
--- a/.actions/git-diff-sync.sh
+++ b/.actions/git-diff-sync.sh
@@ -30,4 +30,3 @@ git merge --ff -s resolve origin/$1
 python _TEMP/.actions/assistant.py group-folders target-diff.txt --fpath_actual_dirs "['dirs-$b1.txt', 'dirs-$b2.txt']"
 printf "\n================\nChanged folders:\n----------------\n" && cat changed-folders.txt
 printf "\n================\nDropped folders:\n----------------\n" && cat dropped-folders.txt
-

--- a/.actions/requires.txt
+++ b/.actions/requires.txt
@@ -1,6 +1,6 @@
 Fire
 tqdm
-PyYAML
+PyYAML <6.0.0  # todo: racing issue with cython compile
 wcmatch
 requests
 pip

--- a/.actions/requires.txt
+++ b/.actions/requires.txt
@@ -1,5 +1,6 @@
 Fire
 tqdm
+cython <3.0.0
 PyYAML <6.0.0  # todo: racing issue with cython compile
 wcmatch
 requests

--- a/.actions/requires.txt
+++ b/.actions/requires.txt
@@ -1,7 +1,6 @@
 Fire
 tqdm
-cython <3.0.0
-PyYAML <6.0.0  # todo: racing issue with cython compile
+PyYAML <5.4  # todo: racing issue with cython compile
 wcmatch
 requests
 pip

--- a/.azure/ipynb-validate.yml
+++ b/.azure/ipynb-validate.yml
@@ -37,6 +37,7 @@ jobs:
         name: mtrx
         displayName: "Changed matrix"
       - bash: echo '$(mtrx.dirs)' | python -m json.tool
+        continueOnError: "true" # not crash if the matrix is empty
         displayName: "Show matrix"
 
   - job: ipython

--- a/.github/workflows/ci_internal.yml
+++ b/.github/workflows/ci_internal.yml
@@ -30,26 +30,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      # Note: This uses an internal pip API and may not always work
-      # https://github.com/actions/cache/blob/master/examples.md#multiple-oss-in-a-workflow
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('.actions/requires.txt') }}-${{ hashFiles('requirements/default.txt') }}
-          restore-keys: ${{ runner.os }}-pip-py${{ matrix.python-version }}-
+          cache: pip
 
       - name: Install requirements
         run: |
-          pip --version
           pip install -q -r .actions/requires.txt -r _requirements/test.txt
           # this is needed to be able to run package version parsing test
           pip install -q -r _requirements/default.txt --find-links https://download.pytorch.org/whl/cpu/torch_stable.html
+          pip list
 
       - name: Prepare dummy inputs
         run: |


### PR DESCRIPTION
## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## What does this PR do?

fixing internal tests and some other notebooks
```
Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [48 lines of output]
      running egg_info
      writing lib3/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib3/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 1[18](https://github.com/Lightning-AI/tutorials/actions/runs/10014342822/job/27683863858?pr=325#step:6:19), in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 271, in <module>
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 108, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 184, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line [20](https://github.com/Lightning-AI/tutorials/actions/runs/10014342822/job/27683863858?pr=325#step:6:21)0, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 970, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 974, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 989, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 3[21](https://github.com/Lightning-AI/tutorials/actions/runs/10014342822/job/27683863858?pr=325#step:6:22), in run
          self.find_sources()
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 329, in find_sources
          mm.run()
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 550, in run
          self.add_defaults()
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 588, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/command/sdist.py", line 102, in add_defaults
          super().add_defaults()
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line [25](https://github.com/Lightning-AI/tutorials/actions/runs/10014342822/job/27683863858?pr=325#step:6:26)0, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 335, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "<string>", line 201, in get_source_files
        File "/tmp/pip-build-env-d6d0ojk0/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
