### PR TITLE
req: lift `pyYAML` version freeze

### DIFF
--- a/.actions/requires.txt
+++ b/.actions/requires.txt
@@ -1,7 +1,7 @@
 Fire
 tqdm
 simplejson
-PyYAML <5.4  # todo: racing issue with cython compile
+PyYAML
 wcmatch
 requests
 pip

--- a/course_UvA-DL/requirements.txt
+++ b/course_UvA-DL/requirements.txt
@@ -1,5 +1,5 @@
 numpy <2.0 # needed for older Torch
-torch>=1.8.1, <2.1.0
-pytorch-lightning>=2.0, <2.1.0
-torchmetrics>=1.0, <1.3
+torch >=1.8.1,<2.1.0
+pytorch-lightning >=2.0,<2.1.0
+torchmetrics >=1.0,<1.3
 matplotlib


### PR DESCRIPTION
## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## What does this PR do?

Addressing https://github.com/Lightning-AI/pytorch-lightning/pull/20111
```
The conflict is caused by:
    The user requested PyYAML<5.4
    lightning 2.4.0.dev0 depends on PyYAML<6.1.0 and >=5.4
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
