### PR TITLE
Fine-Tuning Scheduler Tutorial Update for Lightning/PyTorch `2.4.0`

### DIFF
--- a/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
+++ b/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
@@ -172,13 +172,22 @@ import evaluate
 # Import the `FinetuningScheduler` PyTorch Lightning extension module we want to use. This will import all necessary callbacks.
 import finetuning_scheduler as fts  # isort: split
 
-import lightning as L
+from lightning_utilities.core.imports import module_available  # noqa: I001
+
+if module_available("lightning"):
+    import lightning as L
+    from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
+    from lightning.pytorch.loggers.tensorboard import TensorBoardLogger
+    from lightning.pytorch.utilities import rank_zero_warn
+elif module_available("pytorch_lightning"):
+    import pytorch_lightning as L
+    from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
+    from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
+    from pytorch_lightning.utilities import rank_zero_warn
+
 import sentencepiece as sp  # noqa: F401 # isort: split
 import torch
 from datasets import logging as datasets_logging
-from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
-from lightning.pytorch.loggers.tensorboard import TensorBoardLogger
-from lightning.pytorch.utilities import rank_zero_warn
 from torch.optim.adamw import AdamW
 from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts
 from torch.utils.data import DataLoader

--- a/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
+++ b/lightning_examples/finetuning-scheduler/finetuning-scheduler.py
@@ -172,22 +172,13 @@ import evaluate
 # Import the `FinetuningScheduler` PyTorch Lightning extension module we want to use. This will import all necessary callbacks.
 import finetuning_scheduler as fts  # isort: split
 
-from lightning_utilities.core.imports import module_available  # noqa: I001
-
-if module_available("lightning"):
-    import lightning as L
-    from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
-    from lightning.pytorch.loggers.tensorboard import TensorBoardLogger
-    from lightning.pytorch.utilities import rank_zero_warn
-elif module_available("pytorch_lightning"):
-    import pytorch_lightning as L
-    from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
-    from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
-    from pytorch_lightning.utilities import rank_zero_warn
-
+import lightning as L
 import sentencepiece as sp  # noqa: F401 # isort: split
 import torch
 from datasets import logging as datasets_logging
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
+from lightning.pytorch.loggers.tensorboard import TensorBoardLogger
+from lightning.pytorch.utilities import rank_zero_warn
 from torch.optim.adamw import AdamW
 from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts
 from torch.utils.data import DataLoader

--- a/lightning_examples/finetuning-scheduler/requirements.txt
+++ b/lightning_examples/finetuning-scheduler/requirements.txt
@@ -1,3 +1,3 @@
-datasets >=2.17.*  # to allow explicitly setting `trust_remote_code`
+datasets >=2.17.0  # to allow explicitly setting `trust_remote_code`
 lightning <=2.4.0  # todo: the tuner depends on L so later using with PL crash
-finetuning-scheduler[examples] <=2.4.*
+finetuning-scheduler[examples] <=2.4.0

--- a/lightning_examples/finetuning-scheduler/requirements.txt
+++ b/lightning_examples/finetuning-scheduler/requirements.txt
@@ -1,3 +1,2 @@
 datasets >=2.17.0  # to allow explicitly setting `trust_remote_code`
-lightning <=2.4.0  # todo: the tuner depends on L so later using with PL crash
 finetuning-scheduler[examples] <=2.4.0

--- a/lightning_examples/finetuning-scheduler/requirements.txt
+++ b/lightning_examples/finetuning-scheduler/requirements.txt
@@ -1,6 +1,3 @@
-lightning  # todo: the tuner depends on L so later using with PL crash
-finetuning-scheduler[examples] ==2.3.*
-datasets ==2.17.*
-# todo: pin version intill reinstall with PT-eco alignment
-torch ==2.1.*
-torchvision ==0.16.*
+datasets >=2.17.*  # to allow explicitly setting `trust_remote_code`
+lightning <=2.4.0  # todo: the tuner depends on L so later using with PL crash
+finetuning-scheduler[examples] <=2.4.*


### PR DESCRIPTION
Validated (locally) the Fine-Tuning Scheduler (FTS) tutorial for FTS/Lightning/PyTorch `2.4.0` (as of the [recent `2.4.0` Lightning commit](https://github.com/Lightning-AI/lightning/tree/2064887b12dd934a5f9a2bf45897f29e3bfc74d1)). 
(this PR is currently using `2.3.3` until Lightning and FTS `2.4.x` are released)

The only minor changes in this PR are to explicitly set `datasets` `trust_remote_code` (which will be mandatory with Datasets 3.x) and to remove a reference to the now unsupported PT `2.0.x`

Thank you for all your work and your consistently valuable contributions to the open-source ML community!

## Before submitting

- [X] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [X] Did you make sure to **update the docs**?
- [X] Did you write any new **necessary tests**?

## What does this PR do?

Updates the Fine-Tuning Scheduler tutorial to prepare for `2.4.0` tutorial publishing.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃