### PR TITLE
Refactor basic GAN tutorial

### DIFF
--- a/lightning_examples/basic-gan/gan.py
+++ b/lightning_examples/basic-gan/gan.py
@@ -88,7 +88,7 @@ class Generator(nn.Module):
             layers = [nn.Linear(in_feat, out_feat)]
             if normalize:
                 layers.append(nn.BatchNorm1d(out_feat, 0.8))
-            layers.append(nn.LeakyReLU(0.2, inplace=True))
+            layers.append(nn.LeakyReLU(0.01, inplace=True))
             return layers
 
         self.model = nn.Sequential(
@@ -259,7 +259,7 @@ model = GAN(*dm.dims)
 trainer = pl.Trainer(
     accelerator="auto",
     devices=1,
-    max_epochs=15,
+    max_epochs=5,
 )
 trainer.fit(model, dm)
 

--- a/lightning_examples/basic-gan/gan.py
+++ b/lightning_examples/basic-gan/gan.py
@@ -201,7 +201,7 @@ class GAN(pl.LightningModule):
         valid = valid.type_as(imgs)
 
         # adversarial loss is binary cross-entropy
-        g_loss = self.adversarial_loss(self.discriminator(self(z)), valid)
+        g_loss = self.adversarial_loss(self.discriminator(self.generated_imgs), valid)
         self.log("g_loss", g_loss, prog_bar=True)
         self.manual_backward(g_loss)
         optimizer_g.step()
@@ -222,7 +222,7 @@ class GAN(pl.LightningModule):
         fake = torch.zeros(imgs.size(0), 1)
         fake = fake.type_as(imgs)
 
-        fake_loss = self.adversarial_loss(self.discriminator(self(z).detach()), fake)
+        fake_loss = self.adversarial_loss(self.discriminator(self.generated_imgs.detach()), fake)
 
         # discriminator loss is the average of these
         d_loss = (real_loss + fake_loss) / 2
@@ -259,7 +259,7 @@ model = GAN(*dm.dims)
 trainer = pl.Trainer(
     accelerator="auto",
     devices=1,
-    max_epochs=5,
+    max_epochs=15,
 )
 trainer.fit(model, dm)
 

--- a/lightning_examples/basic-gan/gan.py
+++ b/lightning_examples/basic-gan/gan.py
@@ -193,7 +193,7 @@ class GAN(pl.LightningModule):
         # log sampled images
         sample_imgs = self.generated_imgs[:6]
         grid = torchvision.utils.make_grid(sample_imgs)
-        self.logger.experiment.add_image("generated_images", grid, 0)
+        self.logger.experiment.add_image("train/generated_images", grid, self.current_epoch)
 
         # ground truth result (ie: all fake)
         # put on GPU because we created this tensor inside training_loop
@@ -232,6 +232,9 @@ class GAN(pl.LightningModule):
         optimizer_d.zero_grad()
         self.untoggle_optimizer(optimizer_d)
 
+    def validation_step(self, batch, batch_idx):
+        pass
+
     def configure_optimizers(self):
         lr = self.hparams.lr
         b1 = self.hparams.b1
@@ -247,7 +250,7 @@ class GAN(pl.LightningModule):
         # log sampled images
         sample_imgs = self(z)
         grid = torchvision.utils.make_grid(sample_imgs)
-        self.logger.experiment.add_image("generated_images", grid, self.current_epoch)
+        self.logger.experiment.add_image("validation/generated_images", grid, self.current_epoch)
 
 
 # %%

--- a/lightning_examples/basic-gan/gan.py
+++ b/lightning_examples/basic-gan/gan.py
@@ -266,4 +266,4 @@ trainer.fit(model, dm)
 # %%
 # Start tensorboard.
 # %load_ext tensorboard
-# %tensorboard --logdir lightning_logs/
+# %tensorboard --logdir lightning_logs/ --samples_per_plugin=images=60


### PR DESCRIPTION
## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## What does this PR do?

Fixes https://github.com/Lightning-AI/tutorials/issues/306

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

I had ! Glad to contribute to the best Pytorch wrapper 🙃

## Notes

- The quality of the generated samples remains low, but I don't have the time to tune the architecture more. Also, applying tricks to reach Nash equilibrium like label smoothing could make the example less understandable, so I left it as it is.

- This PR was motivated in the case of some heavy generator and discriminator that we don't want to call multiple times. I removed the repeated calls to the generator (which changes the optimization problem a bit, because the discriminator is trained to detect the same sample that the generator just generated) BUT I did not remove the repeated calls to the discriminator. In fact, trying `self.manual_backward(g_loss, retain_graph=True)` caused an error when backpropagating on the discriminator loss because the generator weights changed (`RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation`).   If anyone knows how to remove the two calls to the discriminator, I'm curious! 

- Logging is fixed and `on_validation_epoch_end` is now called
