### PR TITLE
docs: fix broken link to SelfAttention

### DIFF
--- a/course_UvA-DL/05-transformers-and-MH-attention/MHAttention.py
+++ b/course_UvA-DL/05-transformers-and-MH-attention/MHAttention.py
@@ -118,7 +118,7 @@ for file_name in pretrained_files:
 # * [Attention?
 # Attention!
 # (Lilian Weng, 2018)](https://lilianweng.github.io/lil-log/2018/06/24/attention-attention.html) - A nice blog post summarizing attention mechanisms in many domains including vision.
-# * [Illustrated: Self-Attention (Raimi Karim, 2019)](https://towardsdatascience.com/illustrated-self-attention-2d627e33b20a) - A nice visualization of the steps of self-attention.
+# * [Illustrated: Self-Attention (Raimi Karim, 2019)](https://medium.com/data-science/illustrated-self-attention-2d627e33b20a) - A nice visualization of the steps of self-attention.
 # Recommended going through if the explanation below is too abstract for you.
 # * [The Transformer family (Lilian Weng, 2020)](https://lilianweng.github.io/lil-log/2020/04/07/the-transformer-family.html) - A very detailed blog post reviewing more variants of Transformers besides the original one.
 


### PR DESCRIPTION
## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## What does this PR do?

Fixes broken link and so blocked CI

This pull request includes a small but important update to a URL in the `MHAttention.py` file. The change updates a link to a more accurate source for visualizing self-attention mechanisms.

* [`course_UvA-DL/05-transformers-and-MH-attention/MHAttention.py`](diffhunk://#diff-ff33a3b7435bd87c6d94f9b062c7296d9e3438c327c478eca5e714915a7ca185L121-R121): Updated the URL for "Illustrated: Self-Attention" to a more appropriate link on Medium.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
